### PR TITLE
Hide USDC/USDT addresses from set addresses page

### DIFF
--- a/src/hooks/useWalletBot.ts
+++ b/src/hooks/useWalletBot.ts
@@ -1,5 +1,4 @@
 
-
 import { app } from 'anypay'
 
 import { useState } from 'react'

--- a/src/pages/dashboard/account/wallets.tsx
+++ b/src/pages/dashboard/account/wallets.tsx
@@ -53,7 +53,11 @@ export default function WalletAddresses() {
       
   }
 
-  const coins = data?.data.addresses.filter((coin: any) => !!coin.price)
+  const coins = data?.data.addresses
+    .filter((coin: any) => !!coin.price)
+    .filter((coin: any) => {
+      return coin.code !== 'USDC' && coin.code !== 'USDT'
+    })
   
   return (
     <Page title="Wallets: Setup">


### PR DESCRIPTION
This is necessary at present because we do not yet support explicitly setting ERC20 addresses separate from the root chain address. Without this update it is not possible to set an AVAX address in the current UI.