### PR TITLE
Fix registration route path

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,7 +15,7 @@ module.exports = withTM({
   trailingSlash: true,
   env: {
     DOMAIN: process.env.DOMAIN || 'api.anypayx.com',
-    API_BASE: process.env.API_BASE || 'https://api.anypayx.com/v1/api',
+    API_BASE: process.env.API_BASE || 'https://api.anypayx.com',
     NEXT_PUBLIC_API_BASE: process.env.NEXT_PUBLIC_API_BASE || 'https://api.anypayx.com',
     DEV_HOST_API_KEY: 'http://localhost:8000/v1',
     HOST_API_KEY: 'https://anypayx.com/v1',

--- a/src/contexts/JWTContext.tsx
+++ b/src/contexts/JWTContext.tsx
@@ -141,7 +141,7 @@ function AuthProvider({ children }: AuthProviderProps) {
   };
 
   const register = async (email: string, password: string, firstName: string, lastName: string) => {
-    const response = await axios.post(`${API_BASE}v1/api/account/register`, {
+    const response = await axios.post(`${API_BASE}/v1/api/account/register`, {
       email,
       password,
       firstName,


### PR DESCRIPTION
# Issue
Users can't register on the anypayx.com due typo in the api route path url

<img width="505" alt="image" src="https://github.com/anypay/anypayx.com/assets/17009187/2828e871-7976-4c00-a8f6-5f64a1799a62">

# Things done
* Fixed users registration api typo
* Fixed default base api path in the environment